### PR TITLE
default object for options

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -30,7 +30,13 @@
     export default {
         props: {
             cacheLifetime: { default: 5 },
-            options: { type: Object, required: false },
+            options: { type: Object, required: false,
+              default () {
+                return {
+                  useUrlFragment: true
+                }
+              }
+            }
         },
 
         data: () => ({


### PR DESCRIPTION
As "options" is optional, we need a default object, otherwise the code will fail to access the useUrlFragment attribute in options, as it is undefined.