### PR TITLE
undefined useUrlFragment issue fix

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -75,7 +75,7 @@
 
             selectTab(selectedTabHash, event) {
                 // see if we should store the hash in the url fragment
-                if (event && !this.options.useUrlFragment) {
+                if (event && (this.options === undefined || !this.options.useUrlFragment)) {
                   event.preventDefault();
                 }
 


### PR DESCRIPTION
This error appears when switching tabs:

> TypeError: this.options is undefined
> Call stack:
> 	selectTab
> 	boundFn
> 	click 
> 	invoker 
> 

Here is a gist with minimal bug example https://gist.github.com/lebedevsergey/008122108a345a0885c1c2a50fa11a5c: 

The error happens in code:

```
if (event && !this.options.useUrlFragment) {
	event.preventDefault();
}

```
,and is caused by the fact that this.options value can be undefined.

I quickfixed issue by adding check for this.options value:

```
if (event && (this.options === undefined || !this.options.useUrlFragment)) {
	event.preventDefault();
}
```