### PR TITLE
set library name per target, requires webpack >= 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vue": "^2.3.0",
     "vue-loader": "^12.0.3",
     "vue-template-compiler": "^2.3.0",
-    "webpack": "^2.3.3",
+    "webpack": "^3.12.0",
     "webpack-merge": "^4.1.0"
   },
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,11 @@ module.exports = merge(require('./webpack.base'), {
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
-        library: 'vue-tabs',
+        library: {
+            root: 'VueTabs',
+            amd: 'vue-tabs',
+            commonjs: 'vue-tabs'
+        },
         libraryTarget: 'umd',
     },
 


### PR DESCRIPTION
Hi, this fixes #15 

Starting on webpack 3.1.0, library parameter can be a dictionary, see feature at the very end of https://webpack.js.org/configuration/output/#module-definition-systems

I've updated webpack to version 3 which does not pull in any other dependency

The library name when using a script tag is set to VueTabs, using capitalisation suggested in the webpack example (instead of ‘vuetabs')

Easy testing with docs/index.html and using this code instead of app.js:

```javascript
<script src="https://unpkg.com/vue@2.5.16/dist/vue.js"></script>
<script src="../dist/index.js"></script>
<script>
var Tabs = VueTabs.Tabs;
var Tab = VueTabs.Tab;
var app = new Vue({
    el: '#app',
    components: {
      Tabs,
      Tab
    }
});
</script>
```
