### PR TITLE
emit 'before-change' with active and new tabs

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -98,6 +98,9 @@
                     return;
                 }
 
+                const activeTab = this.findTab(this.activeTabHash);
+                this.$emit('before-change', { activeTab: activeTab, newTab: selectedTab });
+
                 this.tabs.forEach(tab => {
                     tab.isActive = (tab.hash === selectedTab.hash);
                 });


### PR DESCRIPTION
Hi, this is a proposal to fix #54 

Usage:

```
    <tabs @before-change="onBeforeChange" @changed="onChanged">
    ...
    </tabs>
```

```javascript
    methods: {
      onBeforeChange (info) {
        console.log('activeTab', info.activeTab);
        console.log('newTab', info.newTab);
      },
      onChanged (tab) {
        console.log('changed', tab);
      }
    }
```
