### PR TITLE
Prevent a jump to the top of the page when a disabled tab is clicked

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -95,6 +95,7 @@
                 }
 
                 if (selectedTab.isDisabled) {
+                    event.preventDefault();
                     return;
                 }
 


### PR DESCRIPTION
Currently when clicking on a disabled tab, an empty hash is added to URL, and page jumps to the top. There is no way to solve this outside, so here's a PR.